### PR TITLE
[EXE-1082] Compile for scala 2.12 and spark 2.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,6 +348,7 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+.idea
 
 project/project/
 project/target/

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 
 val pkgOrg = Seq("com", "microsoft", "sqlserver", "jdbc", "spark")
 val pkgName = "spark-mssql-connector"
+val s3Base: String = "s3://s3-us-east-1.amazonaws.com/aiq-artifacts"
+val sparkVersion = "2.4.7"
 
 name := "spark-mssql-connector"
 
@@ -12,7 +14,6 @@ version := "1.0.2-aiq1"
 
 scalaVersion := "2.11.12"
 crossScalaVersions := Seq("2.11.12", "2.12.15")
-val sparkVersion = "2.4.7"
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
 
@@ -37,8 +38,6 @@ scalacOptions := Seq("-unchecked", "-deprecation", "evicted")
 // Exclude scala-library from this fat jar. The scala library is already there in spark package.
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 
-val s3Base: String = "s3://s3-us-east-1.amazonaws.com/aiq-artifacts"
-
 s3CredentialsProvider := { (bucket: String) =>
   new AWSCredentialsProviderChain(
     new ProfileCredentialsProvider("default"),
@@ -47,3 +46,4 @@ s3CredentialsProvider := { (bucket: String) =>
 }
 publishMavenStyle := true
 publishTo := Some("AIQ Snapshots" at s"$s3Base/app-bin/snapshots/${pkgOrg.mkString("/")}/${pkgName}/")
+sources in (Compile, doc) := Seq.empty

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,15 @@
 import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 
-val pkgOrg = Seq("com", "microsoft", "sqlserver", "jdbc", "spark")
-val pkgName = "spark-mssql-connector"
-val sparkVersion = "2.4.7"
+name := "spark-mssql-connector"
 
-name := pkgName
-
-organization := pkgOrg.mkString(".")
+organization := "com.microsoft.sqlserver.jdbc.spark"
 
 version := "1.0.2-aiq1"
 
 scalaVersion := "2.12.15"
+
+val sparkVersion = "2.4.6"
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,6 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 
 val pkgOrg = Seq("com", "microsoft", "sqlserver", "jdbc", "spark")
 val pkgName = "spark-mssql-connector"
-val s3Base: String = "s3://s3-us-east-1.amazonaws.com/aiq-artifacts"
 val sparkVersion = "2.4.7"
 
 name := pkgName
@@ -44,7 +43,7 @@ s3CredentialsProvider := { (bucket: String) =>
   )
 }
 publishMavenStyle := true
-publishTo := Some("AIQ Snapshots" at s"$s3Base/app-bin/snapshots/${pkgOrg.mkString("/")}/${pkgName}/")
+publishTo := Some("AIQ Snapshots" at "s3://s3-us-east-1.amazonaws.com/aiq-artifacts/app-bin/snapshots/")
 
 // Publish fails to create docs for some reason
 sources in (Compile, doc) := Seq.empty

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+
 name := "spark-mssql-connector"
 
 organization := "com.microsoft.sqlserver.jdbc.spark"
@@ -24,9 +27,22 @@ libraryDependencies ++= Seq(
 
   //SQLServer JDBC jars
   "com.microsoft.sqlserver" % "mssql-jdbc" % "8.4.1.jre8"
+
 )
 
 scalacOptions := Seq("-unchecked", "-deprecation", "evicted")
 
 // Exclude scala-library from this fat jar. The scala library is already there in spark package.
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
+
+val s3Base: String = "s3://s3-us-east-1.amazonaws.com/aiq-artifacts"
+
+// Loads the credentials from .aws/credentials
+s3CredentialsProvider := { (bucket: String) =>
+  new AWSCredentialsProviderChain(
+    new ProfileCredentialsProvider("default"),
+    DefaultAWSCredentialsProviderChain.getInstance()
+  )
+}
+publishMavenStyle := true
+publishTo := Some("AIQ Snapshots" at s"$s3Base/app-bin/snapshots/com/microsoft/azure/spark-mssql-connector/")

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,12 @@
 import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 
+val pkgOrg = Seq("com", "microsoft", "sqlserver", "jdbc", "spark")
+val pkgName = "spark-mssql-connector"
+
 name := "spark-mssql-connector"
 
-organization := "com.microsoft.sqlserver.jdbc.spark"
+organization := pkgOrg.mkString(".")
 
 version := "1.0.2-aiq1"
 
@@ -27,7 +30,6 @@ libraryDependencies ++= Seq(
 
   //SQLServer JDBC jars
   "com.microsoft.sqlserver" % "mssql-jdbc" % "8.4.1.jre8"
-
 )
 
 scalacOptions := Seq("-unchecked", "-deprecation", "evicted")
@@ -37,7 +39,6 @@ assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeSca
 
 val s3Base: String = "s3://s3-us-east-1.amazonaws.com/aiq-artifacts"
 
-// Loads the credentials from .aws/credentials
 s3CredentialsProvider := { (bucket: String) =>
   new AWSCredentialsProviderChain(
     new ProfileCredentialsProvider("default"),
@@ -45,4 +46,4 @@ s3CredentialsProvider := { (bucket: String) =>
   )
 }
 publishMavenStyle := true
-publishTo := Some("AIQ Snapshots" at s"$s3Base/app-bin/snapshots/com/microsoft/azure/spark-mssql-connector/")
+publishTo := Some("AIQ Snapshots" at s"$s3Base/app-bin/snapshots/${pkgOrg.mkString("/")}/${pkgName}/")

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val pkgName = "spark-mssql-connector"
 val s3Base: String = "s3://s3-us-east-1.amazonaws.com/aiq-artifacts"
 val sparkVersion = "2.4.7"
 
-name := "spark-mssql-connector"
+name := pkgName
 
 organization := pkgOrg.mkString(".")
 
@@ -46,4 +46,6 @@ s3CredentialsProvider := { (bucket: String) =>
 }
 publishMavenStyle := true
 publishTo := Some("AIQ Snapshots" at s"$s3Base/app-bin/snapshots/${pkgOrg.mkString("/")}/${pkgName}/")
+
+// Publish fails to create docs for some reason
 sources in (Compile, doc) := Seq.empty

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "spark-mssql-connector"
 
 organization := "com.microsoft.sqlserver.jdbc.spark"
 
-version := "1.0.0"
+version := "1.0.2-aiq1"
 
 scalaVersion := "2.11.12"
 crossScalaVersions := Seq("2.11.12", "2.12.15")

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ s3CredentialsProvider := { (bucket: String) =>
   )
 }
 publishMavenStyle := true
-publishTo := Some("AIQ Snapshots" at "s3://s3-us-east-1.amazonaws.com/aiq-artifacts/app-bin/snapshots/")
+publishTo := Some("AIQ Releases" at "s3://s3-us-east-1.amazonaws.com/aiq-artifacts/releases/")
 
 // Publish fails to create docs for some reason
 sources in (Compile, doc) := Seq.empty

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ organization := "com.microsoft.sqlserver.jdbc.spark"
 version := "1.0.0"
 
 scalaVersion := "2.11.12"
-
-val sparkVersion = "2.4.6"
+crossScalaVersions := Seq("2.11.12", "2.12.15")
+val sparkVersion = "2.4.7"
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,7 @@ organization := pkgOrg.mkString(".")
 
 version := "1.0.2-aiq1"
 
-scalaVersion := "2.11.12"
-crossScalaVersions := Seq("2.11.12", "2.12.15")
+scalaVersion := "2.12.15"
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
 

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.8")
+addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.20.0")


### PR DESCRIPTION
Forked the repo, checked out the `v1.0.2` tag (which supports scala 2.11 and spark 2.4.6) and modifying it so:

- supports scala 2.12 (dont need 2.11)
- change Spark version to 2.4.7
- add publish to s3

### Test Notes
`sbt test`

### Deploy Notes
`sbt publish`, make sure binaries appear at `s3://aiq-artifacts/app-bin/snapshots/com/microsoft/sqlserver/jdbc/spark/spark-mssql-connector_2.12/1.0.2-aiq1/*`