### PR TITLE
[EXE-1564] Setup deploy to artifactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,9 @@
     </licenses>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <scala.binary.version>2.12</scala.binary.version>
+        <scala.version>2.12.15</scala.version>
+        <spark.version>3.3.2</spark.version>
     </properties>
     <dependencies>
         <dependency>
@@ -58,6 +61,17 @@
             <artifactId>junit-interface</artifactId>
             <version>0.11</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_${scala.binary.version}</artifactId>
+            <version>3.2.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <version>10.2.0.jre17</version>
         </dependency>
     </dependencies>
     <developers>
@@ -187,30 +201,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>spark33</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <scala.binary.version>2.12</scala.binary.version>
-                <scala.version>2.12.15</scala.version>
-                <spark.version>3.3.2</spark.version>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>org.scalatest</groupId>
-                    <artifactId>scalatest_${scala.binary.version}</artifactId>
-                    <version>3.2.6</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>com.microsoft.sqlserver</groupId>
-                    <artifactId>mssql-jdbc</artifactId>
-                    <version>10.2.0.jre17</version>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <scala.binary.version>2.12</scala.binary.version>
         <scala.version>2.12.15</scala.version>
         <spark.version>3.3.2</spark.version>
+        <driver.version>10.2.0.jre17</driver.version>
     </properties>
     <dependencies>
         <dependency>
@@ -34,6 +35,11 @@
             <artifactId>spark-sql_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <version>${driver.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -67,11 +73,6 @@
             <artifactId>scalatest_${scala.binary.version}</artifactId>
             <version>3.2.6</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.microsoft.sqlserver</groupId>
-            <artifactId>mssql-jdbc</artifactId>
-            <version>10.2.0.jre17</version>
         </dependency>
     </dependencies>
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.microsoft.azure</groupId>
     <artifactId>spark-mssql-connector</artifactId>
     <packaging>jar</packaging>
-    <version>1.3.0</version>
+    <version>1.3.0-aiq0</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>The Apache Spark Connector for SQL Server and Azure SQL is a high-performance connector that enables you to use transactional data in big data analytics and persists results for ad-hoc queries or reporting.</description>
     <url>https://github.com/microsoft/sql-spark-connector</url>
@@ -74,12 +74,12 @@
     </scm>
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>aiq-snapshots-artifactory</id>
+            <url>https://actioniq.jfrog.io/artifactory/aiq-sbt-local</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>aiq-releases-artifactory</id>
+            <url>https://actioniq.jfrog.io/artifactory/aiq-sbt-local</url>
         </repository>
     </distributionManagement>
     <build>
@@ -111,21 +111,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
@@ -207,8 +192,8 @@
             </activation>
             <properties>
                 <scala.binary.version>2.12</scala.binary.version>
-                <scala.version>2.12.11</scala.version>
-                <spark.version>3.3.0</spark.version>
+                <scala.version>2.12.15</scala.version>
+                <spark.version>3.3.2</spark.version>
             </properties>
             <dependencies>
                 <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
-    <artifactId>spark-mssql-connector</artifactId>
+    <artifactId>spark-mssql-connector_${scala.binary.version}</artifactId>
     <packaging>jar</packaging>
     <version>1.3.0-aiq0</version>
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -115,8 +115,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -172,6 +172,9 @@
                     <junitxml>.</junitxml>
                     <filereports>TestSuite.txt</filereports>
                     <stdout>W</stdout>
+                    <argLine>
+                        --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+                    </argLine>
                 </configuration>
                 <executions>
                     <execution>
@@ -205,7 +208,7 @@
                 <dependency>
                     <groupId>com.microsoft.sqlserver</groupId>
                     <artifactId>mssql-jdbc</artifactId>
-                    <version>8.4.1.jre8</version>
+                    <version>10.2.0.jre17</version>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
Adding aiq version and scala version, deploying artifacts to jfrog

Moving over everything in `spark33` profile; upgrading `mssql-jdbc` to java 17

`mvn deploy`
```
Uploading to aiq-releases-artifactory: https://actioniq.jfrog.io/artifactory/aiq-sbt-local/com/microsoft/azure/spark-mssql-connector_2.12/1.3.0-aiq0/spark-mssql-connector_2.12-1.3.0-aiq0.pom
Uploaded to aiq-releases-artifactory: https://actioniq.jfrog.io/artifactory/aiq-sbt-local/com/microsoft/azure/spark-mssql-connector_2.12/1.3.0-aiq0/spark-mssql-connector_2.12-1.3.0-aiq0.pom (8.6 kB at 9.0 kB/s)
Uploading to aiq-releases-artifactory: https://actioniq.jfrog.io/artifactory/aiq-sbt-local/com/microsoft/azure/spark-mssql-connector_2.12/1.3.0-aiq0/spark-mssql-connector_2.12-1.3.0-aiq0.jar
Uploading to aiq-releases-artifactory: https://actioniq.jfrog.io/artifactory/aiq-sbt-local/com/microsoft/azure/spark-mssql-connector_2.12/1.3.0-aiq0/spark-mssql-connector_2.12-1.3.0-aiq0-sources.jar
Uploading to aiq-releases-artifactory: https://actioniq.jfrog.io/artifactory/aiq-sbt-local/com/microsoft/azure/spark-mssql-connector_2.12/1.3.0-aiq0/spark-mssql-connector_2.12-1.3.0-aiq0-javadoc.jar
Uploaded to aiq-releases-artifactory: https://actioniq.jfrog.io/artifactory/aiq-sbt-local/com/microsoft/azure/spark-mssql-connector_2.12/1.3.0-aiq0/spark-mssql-connector_2.12-1.3.0-aiq0-sources.jar (34 kB at 59 kB/s)
Uploaded to aiq-releases-artifactory: https://actioniq.jfrog.io/artifactory/aiq-sbt-local/com/microsoft/azure/spark-mssql-connector_2.12/1.3.0-aiq0/spark-mssql-connector_2.12-1.3.0-aiq0.jar (81 kB at 130 kB/s)
Uploaded to aiq-releases-artifactory: https://actioniq.jfrog.io/artifactory/aiq-sbt-local/com/microsoft/azure/spark-mssql-connector_2.12/1.3.0-aiq0/spark-mssql-connector_2.12-1.3.0-aiq0-javadoc.jar (37 kB at 55 kB/s)
Downloading from aiq-releases-artifactory: https://actioniq.jfrog.io/artifactory/aiq-sbt-local/com/microsoft/azure/spark-mssql-connector_2.12/maven-metadata.xml
Downloaded from aiq-releases-artifactory: https://actioniq.jfrog.io/artifactory/aiq-sbt-local/com/microsoft/azure/spark-mssql-connector_2.12/maven-metadata.xml (420 B at 2.4 kB/s)
Uploading to aiq-releases-artifactory: https://actioniq.jfrog.io/artifactory/aiq-sbt-local/com/microsoft/azure/spark-mssql-connector_2.12/maven-metadata.xml
Uploaded to aiq-releases-artifactory: https://actioniq.jfrog.io/artifactory/aiq-sbt-local/com/microsoft/azure/spark-mssql-connector_2.12/maven-metadata.xml (367 B at 741 B/s)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```